### PR TITLE
Fix piramideTest.py 

### DIFF
--- a/tests/progbeta2017/module1/piramideTest.py
+++ b/tests/progbeta2017/module1/piramideTest.py
@@ -5,12 +5,12 @@ import re
 
 @t.test(0)
 def exactMario0(test):
-	test.test = lambda : not assertlib.contains(lib.outputOf(_fileName, [0]), "#")
+	test.test = lambda : not assertlib.contains(lib.outputOf(_fileName, stdinArgs=[0]), "#")
 	test.description = lambda : "print een pyramide van 0 hoog"
 
 @t.test(1)
 def exactMario3(test):
-  test.test = lambda : assertlib.match(lib.outputOf(_fileName, [3]), 
+  test.test = lambda : assertlib.match(lib.outputOf(_fileName, stdinArgs=[3]),
     re.compile(".*"
       "(    # #)[ ]*(\n)"
       "(  # # #)[ ]*(\n)"
@@ -20,7 +20,7 @@ def exactMario3(test):
 
 @t.test(2)
 def exactMario23(test):
-	test.test = lambda : assertlib.match(lib.outputOf(_fileName, [23]),
+	test.test = lambda : assertlib.match(lib.outputOf(_fileName, stdinArgs=[23]),
     re.compile(".*"
       "(                                            # #)[ ]*(\n)"
       "(                                          # # #)[ ]*(\n)"
@@ -51,5 +51,7 @@ def exactMario23(test):
 
 @t.test(10)
 def handlesWrongInput(test):
-	test.test = lambda : not assertlib.contains(lib.outputOf(_fileName, [-100, 100, 24, 0]), "#")
+	test.test = lambda : not assertlib.contains(lib.outputOf(_fileName, stdinArgs=[-100]), "#")
+	test.test = lambda : not assertlib.contains(lib.outputOf(_fileName, stdinArgs=[100]), "#")
+	test.test = lambda : not assertlib.contains(lib.outputOf(_fileName, stdinArgs=[24]), "#")
 	test.description = lambda : "handelt een verkeerde input van -100, 100 en 24 af"


### PR DESCRIPTION
After the WND 2017 workshop of @stgm I have been experimenting with both `checkpy` and [Inleiding Programmeren. ](https://inleiding.mprog.nl).

I ran into some problems with the introductory exercises, ~~because of checkpy breaking (in cache.py) PR later, when time permits) and~~ due to tests breaking. 

Commit message:

The call to checkpy.lib.outputOf() failed because the signature of
checkpy.lib.moduleAndOutputOf() was changed in Jelleas/checkpy@668f0ee

The test for -100, 100 and 24 pushed all three arguments into stdin and ran
the test once.

- use stdinArgs kwarg
- separate tests for -100, 100 and 24

(EDIT: with this fix, checkpy cache works as is)